### PR TITLE
Support multiple directory arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ $ dy k8s_deployment/ | kubectl apply --validate=true --dry-run=true -f -
 deployment.apps/nginx-deployment created (dry run)
 ```
 
+You may pass multiple directories as arguments and they will each be parsed and
+emitted as documents in their own right. In this way a single `dy` invocation
+can be used to produce a valid YAML stream.
+
 ## Installing
 ### Homebrew
 ```

--- a/main.go
+++ b/main.go
@@ -8,18 +8,34 @@ import (
 
 func main() {
 	var dy divvy.DivvyYaml
+	var multiDoc bool
 
 	// Do the most basic argument parsing possible
 	if len(os.Args) < 2 {
-		os.Stderr.WriteString("you must pass a path as an argument\n")
+		os.Stderr.WriteString("you must pass at least one path as an argument\n")
 		os.Exit(1)
 	}
 
-	err := dy.Parse(os.Args[1])
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(2)
-	} else {
-		fmt.Println(dy.Doc)
+	if len(os.Args) > 2 {
+		multiDoc = true
+	}
+
+	// Allow multiple arguments and emit each as a different document
+	for i, dir := range os.Args {
+		if i == 0 {
+			continue
+		}
+
+		err := dy.Parse(dir)
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(2)
+		} else {
+			if multiDoc == true {
+				fmt.Println("---")
+			}
+			fmt.Println(dy.Doc)
+		}
 	}
 }


### PR DESCRIPTION
If multiple directories are passed then each one is emitted as a
distinct YAML document. This means that STDOUT is a valid YAML stream.
In order to not change the existing behaviour the YAML header (`---`) is
only emitted when multiple documents/directories are being parsed.